### PR TITLE
WORKAROUND: jz_sfc_nor.c: use proper erase size

### DIFF
--- a/drivers/mtd/devices/jz_sfc_v1/jz_sfc_nor.c
+++ b/drivers/mtd/devices/jz_sfc_v1/jz_sfc_nor.c
@@ -878,7 +878,9 @@ int jz_sfc_erase(struct spi_flash *flash, u32 offset, size_t len)
 
 	jz_sfc_set_address_mode(flash,1);
 
-	if(len < 0x8000){
+	if(len < (size_t)erase_size) {
+		// use minimum erase size(4k) if len is smaller than predefined
+		// sector_size in jz_spi.h
 		erase_size = 0x1000;
 	}
 
@@ -946,7 +948,7 @@ int jz_sfc_erase(struct spi_flash *flash, u32 offset, size_t len)
 		}
 
 		offset += erase_size;
-		len -= erase_size;
+		len = len > erase_size ? len - erase_size : 0;
 
 		if((erase_size != 0x1000 ) && (len  < erase_size)) {
 			erase_size = 0x1000;


### PR DESCRIPTION
Some flash uses predefined erase size which may be bigger than the minimum alignment size. In that case, the original behavior will erase extra sectors. The length tracking variable will overflow due to a flaw in logic(size_t is unsigned), becoming a enormous value. The whole flash will then be erased.

Use smallest erase size(4K) if erase length is smaller than predefined sector size. Besizes, check if current length is big enough to subtract current erase_size.