### PR TITLE
isvp_common.h: fix CONFIG_DEVICE_ENV guard for uboot-device-env.sh injection (t40)

### DIFF
--- a/include/configs/isvp_common.h
+++ b/include/configs/isvp_common.h
@@ -999,7 +999,9 @@ CONFIG_DEVICE_ENV
 #define CONFIG_GPIO_IRCUT_SETTINGS \
 "gpio_ircut=\0"
 
-#define CONFIG_DEVICE_ENV \
+#ifndef CONFIG_DEVICE_ENV
+#define CONFIG_DEVICE_ENV ""
+#endif
 
 #endif /* CONFIG_BOOTARGS_EXTERNAL */
 


### PR DESCRIPTION
## Problem

The `uboot-device-env.sh` build script uses `awk` to find a `#ifndef CONFIG_DEVICE_ENV` block in `isvp_common.h` and replace it with device-specific environment variables (bootcmd, kern_addr, kern_size, etc.) generated from `uenv.txt` at compile time.

The xburst2 header had a bare `#define CONFIG_DEVICE_ENV \` (empty, incomplete definition) instead of the proper `#ifndef CONFIG_DEVICE_ENV` guard, so the awk pattern `/^#ifndef CONFIG_DEVICE_ENV$/` never matched. The device environment injection was silently skipped, resulting in a U-Boot binary that compiled successfully but had **no bootcmd** and could not boot Linux.

## Fix

Replace the broken bare `#define` with the same guard pattern already used in xburst1:

```c
#ifndef CONFIG_DEVICE_ENV
#define CONFIG_DEVICE_ENV ""
#endif
```

The `uboot-device-env.sh` script then correctly finds the block, replaces it with the generated device environment, and the resulting U-Boot binary includes the proper bootcmd to load and start Linux.

## Verified

Tested and confirmed working on T41 hardware.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author